### PR TITLE
Fix for LoopBack 3.0

### DIFF
--- a/counts.js
+++ b/counts.js
@@ -22,7 +22,7 @@ module.exports = function Counts (Model) {
 
   function extractRelationCounts (ctx) {
     if (!ctx.args || !ctx.args.filter) return [];
-    var filter = JSON.parse(ctx.args.filter);
+    var filter = ctx.args.filter;
     var relations = filter && filter.counts;
     if (!Array.isArray(relations)) relations = [relations];
     return relations.filter(function (relation) {


### PR DESCRIPTION
It looks like in LoopBack 3.0 the format of ctx.args is not JSON anymore but a proper JS object, so no need to use JSON.parse anymore.
