### PR TITLE
Fixed 500 error on non existing parent (#4)

### DIFF
--- a/counts.js
+++ b/counts.js
@@ -6,8 +6,10 @@ module.exports = function Counts (Model) {
   Model.afterRemote('find', injectCounts);
 
   function injectCounts (ctx, unused, next) {
-    var relations = extractRelationCounts(ctx);
     var resources = ctx.result;
+    if (resources == null) return next();
+    
+    var relations = extractRelationCounts(ctx);
     if (!Array.isArray(resources)) resources = [resources];
     if (!relations.length || !resources.length) {
       return next();


### PR DESCRIPTION
Fixed https://github.com/exromany/loopback-counts-mixin/issues/4

Tested against:
findById where ID exists: returns 200 (existing loopback behavior)
findById where ID does not exist: returns 404 (existing loopback behavior)
get where instances exist: returns 200 (existing loopback behavior)
get where instances do not exist: returns 200 (existing loopback behavior)
